### PR TITLE
Fix updating members of merge with dynamic collection

### DIFF
--- a/lib/operator/add-merge.js
+++ b/lib/operator/add-merge.js
@@ -119,11 +119,13 @@ class AdditionCollectionOfCollectionObserver { // implements CollectionObserver
   added(colls, collOfColls) {
     for (let coll of colls) {
       this.addColl._observer.added(coll.contents, coll);
+      coll.registerObserver(this.addColl._observer);
     }
   }
   removed(colls, collOfColls) {
     for (let coll of colls) {
       this.addColl._observer.removed(coll.contents, coll);
+      coll.unregisterObserver(this.addColl._observer);
     }
   }
 }

--- a/test/merge.test.js
+++ b/test/merge.test.js
@@ -149,3 +149,26 @@ test('Merge with dynamic collection', done => {
   });
   colls.add(d);
 });
+
+test('Merge with updating dynamic collection members', () => {
+  let a = new ArrayColl();
+  let b = new ArrayColl();
+  let c = new ArrayColl();
+  let d = new ArrayColl();
+  let colls = new ArrayColl([a, b, c]);
+  let merged = mergeColls(colls);
+  colls.add(d);
+  a.add("a");
+  a.add("b");
+  a.add("c");
+  b.add("a");
+  b.add("b");
+  b.add("f");
+  c.add("a");
+  c.add("b");
+  c.add("i");
+  d.add("j");
+  d.add("a");
+  d.add("b");
+  expect(merged.length).toBe(6);
+});


### PR DESCRIPTION
When collections are added to or removed from the collection of collections passed to `mergeColls`, those collections need to have their listeners added or removed, otherwise changes from those collections won't be observed by the merge.