### PR TITLE
Use WeakSetIterable based on WeakRef for observers, to avoid keeping the observers alive

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1,11 +1,12 @@
 import { assert, arrayRemove } from "./util.js"
+import { WeakSetIterable } from "./collection/weakset.js";
 
 /**
  * This defines the common base API for all collections and operators
  */
 export class Collection {
   constructor() {
-    this._observers = [];
+    this._observers = new WeakSetIterable();
     this._svelteObservers = [];
   }
 
@@ -461,10 +462,7 @@ export class Collection {
     assert(observer);
     assert(typeof (observer.added) == "function",
       "must implement CollectionObserver");
-    if (this._observers.indexOf(observer) != -1) { // already contains it
-      return;
-    }
-    this._observers.push(observer);
+    this._observers.add(observer);
   }
 
   /**
@@ -476,7 +474,7 @@ export class Collection {
     assert(typeof (observer.added) == "function" &&
       typeof (observer.removed) == "function",
       "must implement CollectionObserver");
-    arrayRemove(this._observers, observer, true);
+    this._observers.delete(observer);
   }
 
   _notifyAdded(items) {

--- a/lib/operator/add-concat.js
+++ b/lib/operator/add-concat.js
@@ -41,13 +41,7 @@ const addCollWithDups = concatColl;
  *     Does not preserve order.
  */
 export function concatColls(colls) {
-  let merge = new AdditionCollectionWithDups();
-  for (let coll of colls.contents) {
-    merge.addColl(coll);
-  }
-  merge._colls = colls;
-  colls.registerObserver(new AdditionCollectionOfCollectionObserver(merge));
-  return merge;
+  return new AdditionCollectionOfCollectionWithDups(colls);
 }
 
 /**
@@ -95,5 +89,17 @@ class AdditionCollectionWithDupsObserver { // implements CollectionObserver
 
   removed(items, coll) {
     this.addColl.removeAll(items);
+  }
+}
+
+export class AdditionCollectionOfCollectionWithDups extends AdditionCollectionWithDups {
+  _mergeObserver = null;
+  constructor(colls) {
+    super();
+    for (let coll of colls.contents) {
+      this.addColl(coll);
+    }
+    this._mergeObserver = new AdditionCollectionOfCollectionObserver(this);
+    colls.registerObserver(this._mergeObserver);
   }
 }

--- a/lib/operator/add-merge.js
+++ b/lib/operator/add-merge.js
@@ -39,13 +39,7 @@ export function mergeColl(...colls) {
  *     Does not preserve order.
  */
 export function mergeColls(colls) {
-  let merge = new AdditionCollection();
-  for (let coll of colls.contents) {
-    merge.addColl(coll);
-  }
-  merge._colls = colls;
-  colls.registerObserver(new AdditionCollectionOfCollectionObserver(merge));
-  return merge;
+  return new AdditionCollectionOfCollection(colls);
 }
 
 const addColl = mergeColl;
@@ -127,5 +121,18 @@ export class AdditionCollectionOfCollectionObserver { // implements CollectionOb
       this.addColl._observer.removed(coll.contents, coll);
       coll.unregisterObserver(this.addColl._observer);
     }
+  }
+}
+
+export class AdditionCollectionOfCollection extends AdditionCollection {
+  _mergeObserver = null;
+  constructor(colls) {
+    super();
+    this._colls = colls;
+    for (let coll of colls.contents) {
+      this.addColl(coll);
+    }
+    this._mergeObserver = new AdditionCollectionOfCollectionObserver(this);
+    colls.registerObserver(this._mergeObserver);
   }
 }

--- a/lib/operator/filter.js
+++ b/lib/operator/filter.js
@@ -71,6 +71,7 @@ Collection.prototype.filter = function (filterFunc) {
  *     `item` will be included in FilteredCollection, (only) if `true` is returned
  */
 export class ShallowFilteredCollection extends ArrayColl {
+  _observer = null;
   constructor(source, filterFunc) {
     super();
     assert(typeof (filterFunc) == "function", "must be a function");
@@ -85,8 +86,8 @@ export class ShallowFilteredCollection extends ArrayColl {
       }
     }
 
-    let observer = new ShallowFilteredCollectionObserver(this);
-    source.registerObserver(observer);
+    this._observer = new ShallowFilteredCollectionObserver(this);
+    source.registerObserver(this._observer);
   }
 }
 
@@ -129,6 +130,7 @@ export const FilteredCollection = ShallowFilteredCollection;
  *     `item` will be included in FilteredCollection, (only) if `true` is returned
  */
 export class ObservableFilteredCollection extends ArrayColl {
+  _observer = null;
   constructor(source, filterFunc) {
     super();
     assert(typeof (filterFunc) == "function", "must be a function");
@@ -136,14 +138,14 @@ export class ObservableFilteredCollection extends ArrayColl {
     //this._source = source;
     this._filterFunc = filterFunc;
 
-    let observer = new ObservableFilteredCollectionObserver(this);
-    source.registerObserver(observer);
+    this._observer = new ObservableFilteredCollectionObserver(this);
+    source.registerObserver(this._observer);
 
     // add initial contents
     let sourceArray = source instanceof Collection
       ? source = source.contents
       : source;
-    observer.added(sourceArray);
+    this._observer.added(sourceArray);
   }
 
   // TODO when last observer of filtered collection unsubscribes,

--- a/lib/operator/intersection.js
+++ b/lib/operator/intersection.js
@@ -46,6 +46,7 @@ Collection.prototype.intersect = Collection.prototype.inCommon;
  * E.g. A = abcd, B = bdef, then intersection = bd.
  */
 export class IntersectionCollection extends SetColl {
+  _observer = null;
   constructor(coll1, coll2) {
     super();
     assert(coll1 instanceof Collection, "must be a Collection");
@@ -60,9 +61,9 @@ export class IntersectionCollection extends SetColl {
       }
     }
 
-    let observer = new IntersectionCollectionObserver(this);
-    coll1.registerObserver(observer);
-    coll2.registerObserver(observer);
+    this._observer = new IntersectionCollectionObserver(this);
+    coll1.registerObserver(this._observer);
+    coll2.registerObserver(this._observer);
   }
 }
 

--- a/lib/operator/mapTo.js
+++ b/lib/operator/mapTo.js
@@ -68,6 +68,7 @@ function concatCollsMap(colls) {
  *     The result will be included in MapToCollection
  */
 export class MapToCollection extends ArrayColl {
+  _observer = null;
   constructor(source, mapFunc) {
     super();
     assert(typeof (mapFunc) == "function", "must be a function");
@@ -80,8 +81,8 @@ export class MapToCollection extends ArrayColl {
       this._addWithoutObserver(mapFunc(item));
     }
 
-    let observer = new MapToCollectionObserver(this);
-    source.registerObserver(observer);
+    this._observer = new MapToCollectionObserver(this);
+    source.registerObserver(this._observer);
   }
 }
 

--- a/lib/operator/sort.js
+++ b/lib/operator/sort.js
@@ -74,6 +74,7 @@ export function compareValues(a, b) {
  *     You can use `compareValues()` to compare strings or numbers.
  */
 export class SortedCollection extends ArrayColl {
+  _observer = null;
   constructor(source, sortFunc) {
     super();
     assert(typeof (sortFunc) == "function", "must be a function");
@@ -84,8 +85,8 @@ export class SortedCollection extends ArrayColl {
     // add initial contents
     this.addAll(source.contents.sort(sortFunc));
 
-    let observer = new SortedCollectionObserver(this);
-    source.registerObserver(observer);
+    this._observer = new SortedCollectionObserver(this);
+    source.registerObserver(this._observer);
   }
 
   _addWithoutObserver(item) {

--- a/lib/operator/subtract.js
+++ b/lib/operator/subtract.js
@@ -48,6 +48,8 @@ Collection.prototype.subtract = function (subtractColl) {
  * Set difference @see <http://en.wikipedia.org/wiki/Set_difference>
  */
 export class SubtractCollection extends ArrayColl {
+  _baseObserver = null;
+  _subtractObserver = null;
   constructor(collBase, collSubtract) {
     super();
     assert(collBase instanceof Collection, "must be a Collection");
@@ -58,8 +60,10 @@ export class SubtractCollection extends ArrayColl {
     // add initial contents
     this._reconstruct();
 
-    collBase.registerObserver(new SubtractBaseObserver(this));
-    collSubtract.registerObserver(new SubtractSubstractedObserver(this));
+    this._baseObserver = new SubtractBaseObserver(this);
+    collBase.registerObserver(this._baseObserver);
+    this._subtractObserver = new SubtractSubstractedObserver(this);
+    collSubtract.registerObserver(this._subtractObserver);
   }
 
   _reconstruct() {

--- a/lib/operator/transform.js
+++ b/lib/operator/transform.js
@@ -31,6 +31,7 @@ import { assert } from "../util.js"
  *   items are added or removed to the source collection.
  */
 export class TransformedCollection extends ArrayColl {
+  _observer = null;
   constructor(source, transformFunc) {
     super();
     assert(typeof (transformFunc) == "function", "must be a function");
@@ -43,8 +44,8 @@ export class TransformedCollection extends ArrayColl {
     assert(Array.isArray(initialContents), "transformFunc must return a JS Array");
     this.addAll(initialContents);
 
-    let observer = new TransformedCollectionObserver(this);
-    source.registerObserver(observer);
+    this._observer = new TransformedCollectionObserver(this);
+    source.registerObserver(this._observer);
   }
 
   _recalculate() {

--- a/lib/operator/unique.js
+++ b/lib/operator/unique.js
@@ -17,6 +17,7 @@ Collection.prototype.unique = function (equalFunc = null) {
  *   or compare the values or ID, e.g. `(a, b) => a.id == b.id`.
  */
 export class UniqueCollection extends SetColl {
+  _observer = null;
   constructor(source, equalFunc = null) {
     super();
     assert(equalFunc == null || typeof (equalFunc) == "function", "must be a function");
@@ -24,11 +25,11 @@ export class UniqueCollection extends SetColl {
     this._source = source;
     this._equalFunc = equalFunc;
 
-    let observer = new UniqueCollectionObserver(this);
-    source.registerObserver(observer);
+    this._observer = new UniqueCollectionObserver(this);
+    source.registerObserver(this._observer);
 
     // add initial contents
-    observer.added(source);
+    this._observer.added(source);
   }
 }
 


### PR DESCRIPTION
... but this time, also have the observing collection keep the observers alive for as long as they are, since they're the ones who actually need them.

Not changing Svelte observers as we can assume that they get removed automatically by Svelte.