### PR TITLE
FilteredCollection.filterWritable()

### DIFF
--- a/lib/api.d.ts
+++ b/lib/api.d.ts
@@ -1,4 +1,4 @@
-import type { FilteredCollection, ObservableFilteredCollection } from './operator/filter';
+import type { FilteredCollection, ObservableFilteredCollection, WritableFilteredCollection } from './operator/filter';
 import type { MapToCollection } from './operator/mapTo';
 import type { SortedCollection } from './operator/sort';
 import type { AdditionCollection } from './operator/add-merge';
@@ -175,6 +175,23 @@ declare class Collection<Item> {
    * @param filterFunc A function that accepts up to three arguments. The filter method calls the `filterFunc` function one time for each element in the collection.
    */
   filterObservable(filterFunc: (item: Item) => boolean): ObservableFilteredCollection<Item>;
+  /**
+   * Returns a subset of the source collection.
+   * Which items will be included is defined by `filterFunc`.
+   * This works like `Array.filter()`.
+   *
+   * It's writable, i.e. you can add and remove items from the filtered collection.
+   * The changes will be reflected in the source collection.
+   * 
+   * However, any items added before this filter was applied will not be removed
+   * from the source collection, even if they don't match the filter condition.
+   * Unless there was an update to the item, then it will be removed if it doesn't match anymore.
+   *
+   * @param source {Collection}   Another collection that is to be filtered
+   * @param filterFunc {Function(item)}
+   *     `item` will be included in FilteredCollection, (only) if `true` is returned
+   */
+  filterWritable(filterFunc: (item: Item) => boolean): WritableFilteredCollection<Item>;
   /**
    * Creates a new collection which contains only those items that meet a certain condition.
    * You define that condition by returning true from your `filterFunc`.

--- a/lib/operator/filter.d.ts
+++ b/lib/operator/filter.d.ts
@@ -32,6 +32,26 @@ declare class ObservableFilteredCollection<Item> extends ArrayColl<Item> {
  * Which items will be included is defined by `filterFunc`.
  * This works like `Array.filter()`.
  *
+ * It's writable, i.e. you can add and remove items from the filtered collection.
+ * The changes will be reflected in the source collection.
+ * 
+ * However, any items added before this filter was applied will not be removed
+ * from the source collection, even if they don't match the filter condition.
+ * Unless there was an update to the item, then it will be removed if it doesn't match anymore.
+ *
+ * @param source {Collection}   Another collection that is to be filtered
+ * @param filterFunc {Function(item)}
+ *     `item` will be included in FilteredCollection, (only) if `true` is returned
+ */
+declare class WritableFilteredCollection<Item> extends ObservableFilteredCollection<Item> {
+  constructor(source: Collection<Item>, filterFunc: (item: Item) => boolean);
+}
+
+/**
+ * Returns a subset of the source collection.
+ * Which items will be included is defined by `filterFunc`.
+ * This works like `Array.filter()`.
+ *
  * It's observable, i.e. if the source collection changed and `filterFunc` matches,
  * items will be added and the observers called.
  *

--- a/lib/operator/filter.js
+++ b/lib/operator/filter.js
@@ -38,6 +38,25 @@ Collection.prototype.filterObservable = function (filterFunc) {
  * Which items will be included is defined by `filterFunc`.
  * This works like `Array.filter()`.
  *
+ * It's writable, i.e. you can add and remove items from the filtered collection.
+ * The changes will be reflected in the source collection.
+ * 
+ * However, any items added before this filter was applied will not be removed
+ * from the source collection, even if they don't match the filter condition.
+ * Unless there was an update to the item, then it will be removed if it doesn't match anymore.
+ *
+ * @param filterFunc {Function(item)}
+ *     `item` will be included in FilteredCollection, (only) if `true` is returned
+ */
+Collection.prototype.filterWritable = function (filterFunc) {
+  return new WritableFilteredCollection(this, filterFunc);
+}
+
+/**
+ * Returns a subset of the source collection.
+ * Which items will be included is defined by `filterFunc`.
+ * This works like `Array.filter()`.
+ *
  * It's observable, i.e. if the source collection changed and `filterFunc` matches,
  * items will be added and the observers called.
  *
@@ -197,5 +216,42 @@ class ObservableFilteredCollectionObserver { // implements CollectionObserver
         unsubscribe();
       }
     }
+  }
+}
+
+/**
+ * Returns a subset of the source collection.
+ * Which items will be included is defined by `filterFunc`.
+ * This works like `Array.filter()`.
+ *
+ * It's writable, i.e. you can add and remove items from the filtered collection.
+ * The changes will be reflected in the source collection.
+ * 
+ * However, any items added before this filter was applied will not be removed
+ * from the source collection, even if they don't match the filter condition.
+ * Unless there was an update to the item, then it will be removed if it doesn't match anymore.
+ *
+ * @param source {Collection}   Another collection that is to be filtered
+ * @param filterFunc {Function(item)}
+ *     `item` will be included in FilteredCollection, (only) if `true` is returned
+ */
+export class WritableFilteredCollection extends ObservableFilteredCollection {
+  constructor(source, filterFunc) {
+    super(source, filterFunc);
+    this._source = source;
+  }
+
+  add(item) {
+    if (this._filterFunc(item)) {
+      if (this._source.contains(item)) {
+        super.add(item);
+      } else {
+        this._source.add(item);
+      }
+    }
+  }
+
+  remove(item) {
+    this._source.remove(item);
   }
 }

--- a/test/filter.test.js
+++ b/test/filter.test.js
@@ -106,6 +106,83 @@ test('filterObservable() observable objects', () => {
   expect(added.contents).toMatchObject([itemC]);
 });
 
+test('filterWritable() non-observable objects', () => {
+  let itemA = { valid: true };
+  let itemB = { valid: false };
+  let itemC = { valid: false };
+  let a = new ArrayColl([itemA, itemB, itemC]);
+  let filtered = a.filterWritable(item => item.valid);
+
+  expect(filtered.contents).toMatchObject([itemA]);
+  expect(a.contents).toMatchObject([itemA, itemB, itemC]);
+
+  let itemD = { valid: true };
+  filtered.add(itemD);
+  expect(filtered.contents).toMatchObject([itemA, itemD]);
+  expect(a.contents).toMatchObject([itemA, itemB, itemC, itemD]);
+
+  let itemE = { valid: false };
+  filtered.add(itemE);
+  expect(filtered.contents).toMatchObject([itemA, itemD]);
+
+  expect(a.contents).toMatchObject([itemA, itemB, itemC, itemD]);
+
+  filtered.remove(itemA);
+  expect(filtered.contents).toMatchObject([itemD]);
+  expect(a.contents).toMatchObject([itemB, itemC, itemD]);
+
+  itemB.valid = true;
+  expect(filtered.contents).toMatchObject([itemD]);
+  expect(a.contents).toMatchObject([itemB, itemC, itemD]);
+});
+
+test('filterWritable() observable objects', () => {
+  let itemA = new Leaf(true);
+  let itemB = new Leaf(false);
+  let itemC = new Leaf(false);
+  let a = new ArrayColl([itemA, itemB, itemC]);
+  let filtered = a.filterWritable(item => item.valid);
+
+  expect(filtered.contents).toMatchObject([itemA]);
+  expect(a.contents).toMatchObject([itemA, itemB, itemC]);
+
+  let added = new ArrayColl();
+  let removed = new ArrayColl();
+  filtered.registerObserver({
+    added: (items, coll) => {
+      added.addAll(items);
+    },
+    removed: (items, coll) => {
+      removed.addAll(items);
+    },
+  });
+
+  let itemD = new Leaf(true);
+  filtered.add(itemD);
+  expect(filtered.contents).toMatchObject([itemA, itemD]);
+  expect(a.contents).toMatchObject([itemA, itemB, itemC, itemD]);
+
+  let itemE = new Leaf(false);
+  filtered.add(itemE);
+  expect(filtered.contents).toMatchObject([itemA, itemD]);
+  expect(a.contents).toMatchObject([itemA, itemB, itemC, itemD]);
+
+  filtered.remove(itemA);
+  expect(filtered.contents).toMatchObject([itemD]);
+  expect(a.contents).toMatchObject([itemB, itemC, itemD]);
+
+  itemB.valid = true;
+  expect(filtered.length).toBe(2);
+  expect(a.length).toBe(3);
+
+  itemB.valid = false;
+  expect(filtered.length).toBe(1);
+  expect(a.length).toBe(2);
+
+  expect(added.length).toBe(2);
+  expect(removed.length).toBe(2);
+});
+
 test('filter() (deprecated API) non-observable objects', () => {
   let itemA = { valid: true };
   let itemB = { valid: false };


### PR DESCRIPTION
- filterWritable() returns a filteredCollection but the initial filter will not remove items from the source
- Afterwards any addition will be added to the source and any removal will be removed from the source
- Any updates to any item that cause an addition or removal will be effective to the source collection also
- If an item is already in the source it will not be added again because this will cause duplicates if you're just updating a property.